### PR TITLE
Some edits in the footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,7 +40,7 @@ ignoreFiles = [ "\\.qmd$", "\\.ipynb$", "\\.py$" ]
   dateformat = "January 2, 2006"
   hideCredits = false
   hideCopyright = false
-  since = 2020
+  since = 2023
   rtl = false
   math = true
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,6 +3,7 @@
     <br>
     <a href="https://docs.alliancecan.ca"><img src="/images/favicon.png" width="18"></a>&ensp;&ensp;&nbsp;
     <a href="https://twitter.com/Alliance_Can"><i class="fab fa-twitter fa-lg" style='color: #58585a'></i></a>&ensp;&ensp;
+    <a href="https://vimeo.com/computecanada"><i class="fab fa-vimeo fa-lg" style='color: #58585a'></i></a>&ensp;&ensp;
     <!-- <a href="mailto:training@westgrid.ca"><i class="far fa-envelope-open fa-lg" style='color: #58585a'></i></a>&ensp;&ensp; -->
     <a href="/"><i class="fa fa-home fa-lg" style='color: #58585a'></i></a>
     <div style="font-size: 1.3rem;">


### PR DESCRIPTION
- The lead team has been told to remove the first year of 2020 in the copyright line in the footer. To do that, I have simply set `params.since` to the value of 2023. The code writes a single year when `since` is not less than `now`.
- We wanted to put a link to the Vimeo account where videos will be published.